### PR TITLE
Fwph bound fix

### DIFF
--- a/mpisppy/fwph/fwph.py
+++ b/mpisppy/fwph/fwph.py
@@ -257,7 +257,10 @@ class FWPH(mpisppy.phbase.PHBase):
             # Algorithm 2 lines 6--8
             obj = find_active_objective(mip, True)
             if (itr == 0):
-                dual_bound = pyo.value(obj)
+                if (self.is_minimizing):
+                    dual_bound = mip_results.Problem[0].Lower_bound
+                else:
+                    dual_bound = mip_results.Problem[0].Upper_bound
 
             # Algorithm 2 line 9 (compute \Gamma^t)
             val0 = pyo.value(obj)

--- a/mpisppy/opt/ef.py
+++ b/mpisppy/opt/ef.py
@@ -41,9 +41,13 @@ class ExtensiveForm(mpisppy.spbase.SPBase):
             EF_name=model_name
         )
 
-    def solve_extensive_form(self, tee=False):
+    def solve_extensive_form(self, solver_options=None, tee=False):
         if "persistent" in self.options["solver"]:
             self.solver.set_instance(self.ef)
+        # Pass solver-specifiec (e.g. Gurobi, CPLEX) options
+        if solver_options is not None:
+            for (opt, value) in solver_options.items():
+                self.solver.options[opt] = value
         results = self.solver.solve(self.ef, tee=tee)
         return results
 


### PR DESCRIPTION
Two changes:
1. FWPH now pulls the best bound not the incumbent when computing the bound. This bug had been causing FWPH to sometimes return invalid bounds.
2. Added the ability to pass solver options to the EF solver in ef.py (very minor)