### PR TITLE
Lshaped fixed nonant fix

### DIFF
--- a/mpisppy/opt/lshaped.py
+++ b/mpisppy/opt/lshaped.py
@@ -493,7 +493,7 @@ class LShapedMethod(spbase.SPBase):
 
             if sputils.is_persistent(opt):
                 opt.set_instance(instance)
-                res = opt.solve(tee=True)
+                res = opt.solve(tee=False)
             else:
                 res = opt.solve(instance, tee=False)
 


### PR DESCRIPTION
This PR fixes two issues with LShaped with fixed nonants: 
1. The master problem was having fixed values over-written at the start of LShaped.
2. The subproblem objective construction was factoring out fixed nonants, which ultimately caused invalid cuts