### PR TITLE
Add a few classes to the API doc

### DIFF
--- a/doc/src/api.rst
+++ b/doc/src/api.rst
@@ -91,7 +91,7 @@ spcommunicator
 
 This class handles communication between ranks.
 
-.. automodule:: mpisppy.cylinder.spcommunicator
+.. automodule:: mpisppy.cylinders.spcommunicator
    :members:
    :undoc-members:
    :show-inheritance:
@@ -99,7 +99,7 @@ This class handles communication between ranks.
 spoke
 ^^^^^
 
-.. automodule:: mpisppy.cylinder.spoke
+.. automodule:: mpisppy.cylinders.spoke
    :members:
    :undoc-members:
    :show-inheritance:
@@ -107,7 +107,7 @@ spoke
 hub
 ^^^
 
-.. automodule:: mpisppy.cylinder.hub
+.. automodule:: mpisppy.cylinders.hub
    :members:
    :undoc-members:
    :show-inheritance:

--- a/doc/src/api.rst
+++ b/doc/src/api.rst
@@ -1,11 +1,70 @@
 APIs
 ====
 
+High-level
+----------
+
+For most developers, understanding the API for the high level classes is not
+necessary except perhaps when they want to bypass the examples shared services.
+
+EF class
+^^^^^^^^
+
+This class forms the extensive form and makes it available to send to a solver. It
+also provides some methods to look at the solution.
+
+.. automodule:: mpisppy.opt.ef
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+
+
+PH class
+^^^^^^^^
+
+This is the class for PH hub.
+
+.. automodule:: mpisppy.opt.ph
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+lshaped class
+^^^^^^^^^^^^^
+
+This is the class for L-shapted hub.
+
+.. automodule:: mpisppy.opt.lshaped
+   :members:
+   :undoc-members:
+   :show-inheritance:
+      
+
+
+Mid-level
+---------
+
+Most developers will not want to interact directly with mid-level classes; however,
+they are important to code contributors and to developers who want to create their
+own extensions.
+
+
+phbase.py
+^^^^^^^^^
+
+This is the base class for PH and PH-like algorithms.
+
+.. automodule:: mpisppy.phbase
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 
 spbase.py
 ^^^^^^^^^
 
-Most users will not want to interact directly with the classes in `spbase`.
+This is the base class for many algorithms.
 
 .. automodule:: mpisppy.spbase
    :members:
@@ -15,9 +74,41 @@ Most users will not want to interact directly with the classes in `spbase`.
 scenario_tree.py
 ^^^^^^^^^^^^^^^^
 
-Most users will not want to interact directly with the `scenario_tree` API.
+This provides services for the scenario tree.
 
 .. automodule:: mpisppy.scenario_tree
    :members:
    :undoc-members:
    :show-inheritance:
+
+Low Level
+---------
+
+Most developers will not need to understand the low-level classes.
+
+spcommunicator
+^^^^^^^^^^^^^^
+
+This class handles communication between ranks.
+
+.. automodule:: mpisppy.cylinder.spcommunicator
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+spoke
+^^^^^
+
+.. automodule:: mpisppy.cylinder.spoke
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+hub
+^^^
+
+.. automodule:: mpisppy.cylinder.hub
+   :members:
+   :undoc-members:
+   :show-inheritance:
+   


### PR DESCRIPTION
This demonstrates how difficult it is to get the docstrings to render correctly in sphinx. Maybe not worth the trouble except for a few important classes. (I.e., maybe there should be only a few classes in api.rst). Anyway, this PR results in more than enough classes to see the issues with formatting.